### PR TITLE
Show not authorized 403 fix

### DIFF
--- a/ckanext/questionnaire/plugin.py
+++ b/ckanext/questionnaire/plugin.py
@@ -15,7 +15,7 @@ class QuestionnairePlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.ITemplateHelpers)
     plugins.implements(plugins.IBlueprint)
     plugins.implements(plugins.IClick)
-    plugins.implements(plugins.IAuthenticator)
+    plugins.implements(plugins.IAuthenticator, inherit=True)
     plugins.implements(plugins.IActions)
     plugins.implements(plugins.IAuthFunctions)
 


### PR DESCRIPTION
Fixes the error 500 that shows when user goes to restricted url for him. It now shows 403 Forbidden as it should.